### PR TITLE
Fix auto-refresh feed updates

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log/slog"
 
+	"github.com/GeorgijGrigoriev/RapidFeed/internal/feeder"
 	"github.com/GeorgijGrigoriev/RapidFeed/internal/http"
 	"github.com/GeorgijGrigoriev/RapidFeed/internal/mcp"
 	"github.com/GeorgijGrigoriev/RapidFeed/internal/utils"
@@ -47,6 +48,7 @@ func init() {
 
 func main() {
 	slog.Info("Starting RapidFeed server")
+	go feeder.StartAutoRefresh()
 	go func() {
 		slog.Info("Starting RapidFeed MCP server", "listen", utils.MCPListen)
 		if err := mcp.Start(utils.MCPListen); err != nil {

--- a/internal/db/userFeedsRefresher.go
+++ b/internal/db/userFeedsRefresher.go
@@ -69,6 +69,10 @@ func GetNextUpdateTS(userID int) (time.Time, error) {
 
 	err := DB.QueryRow(query, userID).Scan(&timestampStr)
 	if err != nil {
+		if err == sql.ErrNoRows {
+			return time.Time{}, nil
+		}
+
 		return time.Time{}, err
 	}
 
@@ -94,6 +98,10 @@ func GetLastUpdateTS(userID int) (time.Time, error) {
 
 	err := DB.QueryRow(query, userID).Scan(&timestampStr)
 	if err != nil {
+		if err == sql.ErrNoRows {
+			return time.Time{}, nil
+		}
+
 		return time.Time{}, err
 	}
 

--- a/internal/feeder/autoRefresh.go
+++ b/internal/feeder/autoRefresh.go
@@ -41,14 +41,14 @@ func refreshAllUsersFeeds() {
 			continue
 		}
 
-		lastUpdateTS, err := db.GetLastUpdateTS(user.ID)
+		nextUpdateTS, err := db.GetNextUpdateTS(user.ID)
 		if err != nil {
-			slog.Error("failed to get last update TS", "error", err)
+			slog.Error("failed to get next update TS", "error", err)
 
 			continue
 		}
 
-		shouldUpdate := lastUpdateTS.IsZero() || time.Now().After(lastUpdateTS)
+		shouldUpdate := nextUpdateTS.IsZero() || time.Now().After(nextUpdateTS)
 
 		if !shouldUpdate {
 			continue


### PR DESCRIPTION
### Motivation
- The auto-refresh background worker wasn't started and the refresh logic used the wrong timestamp which prevented scheduled updates from running correctly.
- Missing DB rows for refresh timestamps caused errors instead of being treated as "no scheduled update".

### Description
- Start the auto-refresh worker at server startup by calling `go feeder.StartAutoRefresh()` in `cmd/main.go` and importing the `feeder` package.
- Use `GetNextUpdateTS` (instead of the last-update timestamp) in `internal/feeder/autoRefresh.go` to decide when to fetch feeds next and update related log messages.
- Treat `sql.ErrNoRows` as an empty timestamp in `internal/db/userFeedsRefresher.go` for both `GetNextUpdateTS` and `GetLastUpdateTS` so missing rows do not return an error.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983ab9f002c83278d8c652f950ee96f)